### PR TITLE
[feat] oauth2ResourceServer에서 JWT를 요청자 객체로 변환해 AuthenticationPrincipal로 사용하도록 수정

### DIFF
--- a/tomo/auth/src/main/kotlin/place/tomo/auth/application/services/AuthenticationApplicationService.kt
+++ b/tomo/auth/src/main/kotlin/place/tomo/auth/application/services/AuthenticationApplicationService.kt
@@ -38,12 +38,12 @@ class AuthenticationApplicationService(
             ),
         )
 
-        return issueToken(oidcUserInfo.email)
+        return issueToken(userInfo.entityId.toString())
     }
 
     fun refreshToken(request: RefreshTokenRequest): IssueTokenResponse {
         val subject = jwtValidator.validateRefreshToken(request.refreshToken)
-        userDomainPort.findActiveByEmail(subject) ?: throw NotFoundActiveUserException(subject)
+        userDomainPort.findActiveByEntityId(subject) ?: throw NotFoundActiveUserException(subject)
 
         return issueToken(subject)
     }

--- a/tomo/auth/src/test/kotlin/place/tomo/auth/application/services/AuthenticationApplicationServiceTest.kt
+++ b/tomo/auth/src/test/kotlin/place/tomo/auth/application/services/AuthenticationApplicationServiceTest.kt
@@ -210,7 +210,7 @@ class AuthenticationApplicationServiceTest {
             val userInfo = createUserInfo(email)
 
             every { jwtValidator.validateRefreshToken(refreshToken) } returns email
-            every { userDomainPort.findActiveByEmail(email) } returns userInfo
+            every { userDomainPort.findActiveByEntityId(email) } returns userInfo
 
             val newAccessToken = issueToken(false)
             val newRefreshToken = issueToken(true)
@@ -245,7 +245,7 @@ class AuthenticationApplicationServiceTest {
             every {
                 jwtValidator.validateRefreshToken(refreshToken)
             } returns userEmail
-            every { userDomainPort.findActiveByEmail(userEmail) } throws NotFoundActiveUserException(userEmail)
+            every { userDomainPort.findActiveByEntityId(userEmail) } throws NotFoundActiveUserException(userEmail)
 
             assertThatThrownBy { service.refreshToken(RefreshTokenRequest(refreshToken)) }
                 .isInstanceOf(NotFoundActiveUserException::class.java)

--- a/tomo/auth/src/test/kotlin/place/tomo/auth/application/services/AuthenticationApplicationServiceTest.kt
+++ b/tomo/auth/src/test/kotlin/place/tomo/auth/application/services/AuthenticationApplicationServiceTest.kt
@@ -207,16 +207,16 @@ class AuthenticationApplicationServiceTest {
         @DisplayName("유효한 refresh token으로 요청 시 새로운 토큰을 반환한다")
         fun `refresh token when valid expect new tokens returned`() {
             val refreshToken = faker.internet().password()
-            val email = faker.internet().emailAddress()
-            val userInfo = createUserInfo(email)
+            val entityId = UUID.randomUUID()
+            val userInfo = createUserInfo(entityId = entityId)
 
-            every { jwtValidator.validateRefreshToken(refreshToken) } returns email
-            every { userDomainPort.findActiveByEntityId(email) } returns userInfo
+            every { jwtValidator.validateRefreshToken(refreshToken) } returns entityId.toString()
+            every { userDomainPort.findActiveByEntityId(entityId.toString()) } returns userInfo
 
             val newAccessToken = issueToken(false)
             val newRefreshToken = issueToken(true)
-            every { jwtProvider.issueAccessToken(email) } returns newAccessToken
-            every { jwtProvider.issueRefreshToken(email) } returns newRefreshToken
+            every { jwtProvider.issueAccessToken(userInfo.entityId.toString()) } returns newAccessToken
+            every { jwtProvider.issueRefreshToken(userInfo.entityId.toString()) } returns newRefreshToken
 
             val result = service.refreshToken(RefreshTokenRequest(refreshToken))
 
@@ -256,7 +256,8 @@ class AuthenticationApplicationServiceTest {
     private fun createUserInfo(
         email: String = faker.internet().emailAddress(),
         name: String = faker.name().username(),
-    ): UserInfoDTO = UserInfoDTO(faker.number().numberBetween(1L, 1000L), UUID.randomUUID(), email, name)
+        entityId: UUID = UUID.randomUUID(),
+    ): UserInfoDTO = UserInfoDTO(faker.number().numberBetween(1L, 1000L), entityId, email, name)
 
     private fun createOidcUserInfo(
         email: String = faker.internet().emailAddress(),

--- a/tomo/auth/src/test/kotlin/place/tomo/auth/application/services/AuthenticationApplicationServiceTest.kt
+++ b/tomo/auth/src/test/kotlin/place/tomo/auth/application/services/AuthenticationApplicationServiceTest.kt
@@ -27,6 +27,7 @@ import place.tomo.contract.constant.OIDCProviderType
 import place.tomo.contract.dtos.UserInfoDTO
 import place.tomo.contract.ports.UserDomainPort
 import java.time.Instant
+import java.util.UUID
 
 @DisplayName("AuthenticationApplicationService")
 class AuthenticationApplicationServiceTest {
@@ -72,8 +73,8 @@ class AuthenticationApplicationServiceTest {
 
             val accessToken = issueToken(false)
             val refreshToken = issueToken(true)
-            every { jwtProvider.issueAccessToken(email) } returns accessToken
-            every { jwtProvider.issueRefreshToken(email) } returns refreshToken
+            every { jwtProvider.issueAccessToken(userInfo.entityId.toString()) } returns accessToken
+            every { jwtProvider.issueRefreshToken(userInfo.entityId.toString()) } returns refreshToken
 
             service.signUp(
                 OIDCSignUpRequest(oidcInfo.provider, authorizationCode = faker.internet().password()),
@@ -98,8 +99,8 @@ class AuthenticationApplicationServiceTest {
 
             val accessToken = issueToken(false)
             val refreshToken = issueToken(true)
-            every { jwtProvider.issueAccessToken(email) } returns accessToken
-            every { jwtProvider.issueRefreshToken(email) } returns refreshToken
+            every { jwtProvider.issueAccessToken(userInfo.entityId.toString()) } returns accessToken
+            every { jwtProvider.issueRefreshToken(userInfo.entityId.toString()) } returns refreshToken
 
             val response =
                 service.signUp(
@@ -130,8 +131,8 @@ class AuthenticationApplicationServiceTest {
 
             val accessToken = issueToken(false)
             val refreshToken = issueToken(true)
-            every { jwtProvider.issueAccessToken(email) } returns accessToken
-            every { jwtProvider.issueRefreshToken(email) } returns refreshToken
+            every { jwtProvider.issueAccessToken(userInfo.entityId.toString()) } returns accessToken
+            every { jwtProvider.issueRefreshToken(userInfo.entityId.toString()) } returns refreshToken
 
             service.signUp(OIDCSignUpRequest(oidcInfo.provider, authorizationCode = faker.internet().password()))
 
@@ -255,7 +256,7 @@ class AuthenticationApplicationServiceTest {
     private fun createUserInfo(
         email: String = faker.internet().emailAddress(),
         name: String = faker.name().username(),
-    ): UserInfoDTO = UserInfoDTO(faker.number().numberBetween(1L, 1000L), email, name)
+    ): UserInfoDTO = UserInfoDTO(faker.number().numberBetween(1L, 1000L), UUID.randomUUID(), email, name)
 
     private fun createOidcUserInfo(
         email: String = faker.internet().emailAddress(),

--- a/tomo/auth/src/test/kotlin/place/tomo/auth/domain/services/SocialAccountDomainServiceTest.kt
+++ b/tomo/auth/src/test/kotlin/place/tomo/auth/domain/services/SocialAccountDomainServiceTest.kt
@@ -18,6 +18,7 @@ import place.tomo.auth.domain.exception.SocialAccountNotFoundException
 import place.tomo.auth.infra.repositories.SocialAccountRepository
 import place.tomo.contract.constant.OIDCProviderType
 import place.tomo.contract.dtos.UserInfoDTO
+import java.util.UUID
 
 @DisplayName("SocialAccountDomainService")
 class SocialAccountDomainServiceTest {
@@ -173,7 +174,7 @@ class SocialAccountDomainServiceTest {
     }
 
     private fun createLinkSocialAccountCommand(email: String): LinkSocialAccountCommand {
-        val userInfo = UserInfoDTO(1, email, faker.name().username())
+        val userInfo = UserInfoDTO(1, UUID.randomUUID(), email, faker.name().username())
 
         return LinkSocialAccountCommand(
             userInfo,

--- a/tomo/auth/src/test/kotlin/place/tomo/auth/domain/services/jwt/JwtValidatorTest.kt
+++ b/tomo/auth/src/test/kotlin/place/tomo/auth/domain/services/jwt/JwtValidatorTest.kt
@@ -73,7 +73,6 @@ class JwtValidatorTest {
             assertThatThrownBy { service.validateRefreshToken(notRefreshToken) }
                 .isInstanceOf(InvalidRefreshTokenException::class.java)
                 .message()
-                .isEqualTo("유효하지 않은 토큰 유형입니다.")
         }
 
         @Test
@@ -90,7 +89,6 @@ class JwtValidatorTest {
             assertThatThrownBy { service.validateRefreshToken(typeNullRefreshToken) }
                 .isInstanceOf(InvalidRefreshTokenException::class.java)
                 .message()
-                .isEqualTo("유효하지 않은 토큰 유형입니다.")
         }
     }
 }

--- a/tomo/contract/src/main/kotlin/place/tomo/contract/dtos/AuthorizedUserDTO.kt
+++ b/tomo/contract/src/main/kotlin/place/tomo/contract/dtos/AuthorizedUserDTO.kt
@@ -1,0 +1,7 @@
+package place.tomo.contract.dtos
+
+data class AuthorizedUserDTO(
+    val id: Long,
+    val email: String,
+    val entityId: String,
+)

--- a/tomo/contract/src/main/kotlin/place/tomo/contract/dtos/UserInfoDTO.kt
+++ b/tomo/contract/src/main/kotlin/place/tomo/contract/dtos/UserInfoDTO.kt
@@ -1,7 +1,10 @@
 package place.tomo.contract.dtos
 
+import java.util.UUID
+
 data class UserInfoDTO(
     val id: Long,
+    val entityId: UUID,
     val email: String,
     val name: String,
 )

--- a/tomo/contract/src/main/kotlin/place/tomo/contract/ports/UserDomainPort.kt
+++ b/tomo/contract/src/main/kotlin/place/tomo/contract/ports/UserDomainPort.kt
@@ -1,15 +1,14 @@
 package place.tomo.contract.ports
 
 import place.tomo.contract.dtos.UserInfoDTO
-import place.tomo.contract.vo.UserId
 
 interface UserDomainPort {
-    fun findActiveByEmail(email: String): UserInfoDTO?
+    fun findActiveByEntityId(entityId: String): UserInfoDTO?
 
     fun getOrCreateActiveUser(
         email: String,
         name: String?,
     ): UserInfoDTO
 
-    fun softDelete(userId: UserId)
+    fun softDelete(userId: Long)
 }

--- a/tomo/contract/src/main/kotlin/place/tomo/contract/vo/UserId.kt
+++ b/tomo/contract/src/main/kotlin/place/tomo/contract/vo/UserId.kt
@@ -1,6 +1,0 @@
-package place.tomo.contract.vo
-
-@JvmInline
-value class UserId(val value: Long)
-
-

--- a/tomo/tomo/src/main/kotlin/place/tomo/infra/config/security/JwtConfig.kt
+++ b/tomo/tomo/src/main/kotlin/place/tomo/infra/config/security/JwtConfig.kt
@@ -23,13 +23,13 @@ import place.tomo.auth.domain.exception.InvalidJwtSecretException
 import place.tomo.common.exception.NotFoundActiveUserException
 import place.tomo.contract.dtos.AuthorizedUserDTO
 import place.tomo.contract.ports.UserDomainPort
-import java.util.UUID
 import javax.crypto.spec.SecretKeySpec
 
 @Configuration
 class JwtConfig(
     private val properties: JwtPropertiesDTO,
     @Value("\${security.jwt.secret}") private val jwtSecret: String,
+    private val userDomainPort: UserDomainPort,
 ) {
     companion object {
         const val SECRET_MIN_LENGTH = 32
@@ -56,7 +56,7 @@ class JwtConfig(
     }
 
     @Bean
-    fun jwtAuthenticationConverter(userDomainPort: UserDomainPort): Converter<Jwt, out AbstractAuthenticationToken> =
+    fun jwtAuthenticationConverter(): Converter<Jwt, out UsernamePasswordAuthenticationToken> =
         Converter { jwt ->
             val user =
                 userDomainPort.findActiveByEntityId(jwt.subject)

--- a/tomo/tomo/src/main/kotlin/place/tomo/infra/config/security/JwtConfig.kt
+++ b/tomo/tomo/src/main/kotlin/place/tomo/infra/config/security/JwtConfig.kt
@@ -4,6 +4,9 @@ import com.nimbusds.jose.jwk.source.ImmutableSecret
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
 import org.springframework.security.oauth2.core.OAuth2Error
 import org.springframework.security.oauth2.core.OAuth2TokenValidator
@@ -17,6 +20,10 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder
 import place.tomo.auth.domain.dtos.JwtPropertiesDTO
 import place.tomo.auth.domain.exception.InvalidJwtSecretException
+import place.tomo.common.exception.NotFoundActiveUserException
+import place.tomo.contract.dtos.AuthorizedUserDTO
+import place.tomo.contract.ports.UserDomainPort
+import java.util.UUID
 import javax.crypto.spec.SecretKeySpec
 
 @Configuration
@@ -47,6 +54,23 @@ class JwtConfig(
 
         return decoder
     }
+
+    @Bean
+    fun jwtAuthenticationConverter(userDomainPort: UserDomainPort): Converter<Jwt, out AbstractAuthenticationToken> =
+        Converter { jwt ->
+            val user =
+                userDomainPort.findActiveByEntityId(jwt.subject)
+                    ?: throw NotFoundActiveUserException(jwt.subject)
+
+            val authorizedUser =
+                AuthorizedUserDTO(
+                    id = user.id,
+                    entityId = jwt.subject,
+                    email = user.email,
+                )
+
+            UsernamePasswordAuthenticationToken(authorizedUser, "n/a", emptyList())
+        }
 
     private fun createDecoderValidator(): DelegatingOAuth2TokenValidator<Jwt> {
         val withIssuer: OAuth2TokenValidator<Jwt> =

--- a/tomo/tomo/src/test/kotlin/place/tomo/infra/config/security/JwtConfigTest.kt
+++ b/tomo/tomo/src/test/kotlin/place/tomo/infra/config/security/JwtConfigTest.kt
@@ -1,5 +1,7 @@
 package place.tomo.infra.config.security
 
+import io.mockk.every
+import io.mockk.mockk
 import net.datafaker.Faker
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -7,12 +9,21 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Primary
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtEncoder
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
@@ -21,13 +32,26 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import place.tomo.auth.domain.dtos.JwtPropertiesDTO
+import place.tomo.auth.domain.exception.InvalidJwtSecretException
 import place.tomo.auth.domain.services.jwt.JwtProvider
+import place.tomo.common.exception.NotFoundActiveUserException
+import place.tomo.contract.dtos.AuthorizedUserDTO
+import place.tomo.contract.dtos.UserInfoDTO
+import place.tomo.contract.ports.UserDomainPort
 import java.time.Instant
+import java.util.UUID
+
+@TestConfiguration
+class MockConfig {
+    @Bean
+    @Primary
+    fun mockUserDomainPort(): UserDomainPort = mockk()
+}
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [JwtConfig::class])
 @EnableConfigurationProperties(JwtPropertiesDTO::class)
-@TestPropertySource(locations = ["classpath:application-test.properties"]) // 명시적으로 추가
+@TestPropertySource(locations = ["classpath:application-test.properties"])
 @ComponentScan(
     basePackages = [
         "place.tomo.auth.domain.services.jwt",
@@ -41,6 +65,7 @@ import java.time.Instant
         ),
     ],
 )
+@Import(MockConfig::class)
 @DisplayName("JwtConfigTest")
 class JwtConfigTest {
     @Autowired
@@ -53,10 +78,16 @@ class JwtConfigTest {
     private lateinit var jwtDecoder: JwtDecoder
 
     @Autowired
+    private lateinit var jwtAuthenticationConverter: Converter<Jwt, out UsernamePasswordAuthenticationToken>
+
+    @Autowired
     private lateinit var jwtPropertiesDTO: JwtPropertiesDTO
 
     @Autowired
     private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var userDomainPort: UserDomainPort
 
     private val faker = Faker()
 
@@ -78,6 +109,37 @@ class JwtConfigTest {
             val jwtDecoder = applicationContext.getBean(JwtDecoder::class.java)
             assertThat(jwtDecoder).isNotNull()
             assertThat(jwtDecoder).isInstanceOf(NimbusJwtDecoder::class.java)
+
+            val jwtAuthenticationConverter = applicationContext.getBean(Converter::class.java)
+            assertThat(jwtAuthenticationConverter).isNotNull()
+            assertThat(jwtAuthenticationConverter).isInstanceOf(Converter::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("JwtEncoder")
+    inner class JwtEncoderTest {
+        @Test
+        @DisplayName("jwt secret의 길이가 32byte 미만인 경우 오류 처리")
+        fun `jwt encoder when jwt secret length is less thatn 32byte expect exception`() {
+            // Given
+            val shortSecret = "short"
+            val jwtConfigWithShortSecret = JwtConfig(jwtPropertiesDTO, shortSecret, userDomainPort)
+
+            // When & Then
+            assertThatThrownBy { jwtConfigWithShortSecret.jwtEncoder() }
+                .isInstanceOf(InvalidJwtSecretException::class.java)
+        }
+
+        @Test
+        @DisplayName("유효한 길이의 시크릿으로 JwtEncoder 생성 성공")
+        fun `jwtConfig when valid secret length expect successful jwtEncoder creation`() {
+            // Given
+            val validSecret = "this-is-a-valid-secret-key-with-32-characters-or-more"
+            val jwtConfigWithValidSecret = JwtConfig(jwtPropertiesDTO, validSecret, userDomainPort)
+
+            // When & Then
+            assertDoesNotThrow { jwtConfigWithValidSecret.jwtEncoder() }
         }
     }
 
@@ -123,6 +185,66 @@ class JwtConfigTest {
             val jwtToken = jwtProvider.issueAccessToken(faker.internet().emailAddress())
 
             assertThatThrownBy { jwtDecoder.decode(jwtToken.token) }
+        }
+    }
+
+    @Nested
+    @DisplayName("JwtAuthenticationConverter")
+    inner class JwtAuthenticationConverterTest {
+        @Test
+        @DisplayName("jwt subject에 해당하는 사용자가 없는 경우, 오류 처리")
+        fun `converter when no user corresponding subject expect exception`() {
+            val noUserSubject = faker.internet().uuid()
+            val mockJwt =
+                mockk<Jwt> {
+                    every { subject } returns noUserSubject
+                }
+
+            every { userDomainPort.findActiveByEntityId(noUserSubject) } returns null
+
+            assertThatThrownBy { jwtAuthenticationConverter.convert(mockJwt) }
+                .isInstanceOf(NotFoundActiveUserException::class.java)
+        }
+
+        @Test
+        @DisplayName("jwt subject에 해당하는 사용자가 비활성화인 경우, 오류 처리")
+        fun `converter when deactivated user corresponding subject expect exception`() {
+            val deactivatedUserSubject = faker.internet().uuid()
+            val mockJwt =
+                mockk<Jwt> {
+                    every { subject } returns deactivatedUserSubject
+                }
+            every { userDomainPort.findActiveByEntityId(deactivatedUserSubject) } throws
+                NotFoundActiveUserException(faker.internet().emailAddress())
+
+            assertThatThrownBy { jwtAuthenticationConverter.convert(mockJwt) }
+                .isInstanceOf(NotFoundActiveUserException::class.java)
+        }
+
+        @Test
+        @DisplayName("jwt subject가 유효한 사용자인 경우, AbstractAuthenticationToken 생성")
+        fun `converter when valid subject and usre expect AbstractAuthenticationToken`() {
+            val validSubject = faker.internet().uuid()
+            val mockJwt =
+                mockk<Jwt> {
+                    every { subject } returns validSubject
+                }
+            val foundActiveUser =
+                UserInfoDTO(
+                    id = faker.random().nextLong(),
+                    entityId = UUID.fromString(validSubject),
+                    email = faker.internet().emailAddress(),
+                    name = faker.name().username(),
+                )
+
+            every { userDomainPort.findActiveByEntityId(validSubject) } returns foundActiveUser
+
+            val authenticationToken = jwtAuthenticationConverter.convert(mockJwt)
+            assertThat(authenticationToken).isInstanceOf(UsernamePasswordAuthenticationToken::class.java)
+            assertThat(authenticationToken!!.principal).isInstanceOf(AuthorizedUserDTO::class.java)
+            assertThat(
+                authenticationToken.principal,
+            ).isEqualTo(AuthorizedUserDTO(foundActiveUser.id, foundActiveUser.email, foundActiveUser.entityId.toString()))
         }
     }
 

--- a/tomo/tomo/src/test/kotlin/place/tomo/infra/config/security/SecurityFilterChainConfigTest.kt
+++ b/tomo/tomo/src/test/kotlin/place/tomo/infra/config/security/SecurityFilterChainConfigTest.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfig
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.ApplicationContext
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers

--- a/tomo/user/src/main/kotlin/place/tomo/user/domain/entities/UserEntity.kt
+++ b/tomo/user/src/main/kotlin/place/tomo/user/domain/entities/UserEntity.kt
@@ -8,7 +8,9 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -17,13 +19,24 @@ import place.tomo.user.domain.constant.UserStatus
 import place.tomo.user.domain.exception.InvalidEmailException
 import place.tomo.user.domain.exception.InvalidUsernameException
 import java.time.LocalDateTime
+import java.util.UUID
 
 @Entity
-@Table(name = "users")
+@Table(
+    name = "users",
+    indexes = [
+        Index(name = "idx_entity_id", columnList = "entity_id"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_user__email", columnNames = ["email"]),
+    ],
+)
 @EntityListeners(AuditingEntityListener::class)
 class UserEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
+    @Column(name = "entity_id", nullable = false)
+    val entityId: UUID = UUID.randomUUID(),
     @Column(unique = true, nullable = false)
     val email: String,
     @Column(nullable = false)
@@ -58,6 +71,11 @@ class UserEntity(
                 username = username,
             )
         }
+    }
+
+    fun deactivate() {
+        status = UserStatus.DEACTIVATED
+        deletedAt = LocalDateTime.now()
     }
 
     fun isActivated(): Boolean = status == UserStatus.ACTIVATED

--- a/tomo/user/src/main/kotlin/place/tomo/user/infra/adapters/UserDomainAdapter.kt
+++ b/tomo/user/src/main/kotlin/place/tomo/user/infra/adapters/UserDomainAdapter.kt
@@ -1,6 +1,7 @@
 package place.tomo.user.infra.adapters
 
 import org.springframework.stereotype.Component
+import place.tomo.common.exception.NotFoundActiveUserException
 import place.tomo.contract.dtos.UserInfoDTO
 import place.tomo.contract.ports.UserDomainPort
 import place.tomo.user.domain.services.UserDomainService
@@ -14,7 +15,9 @@ class UserDomainAdapter(
 ) : UserDomainPort {
     override fun findActiveByEntityId(entityId: String): UserInfoDTO? {
         val user = userRepository.findByEntityIdAndDeletedAtIsNull(UUID.fromString(entityId)) ?: return null
-        require(user.isActivated())
+        if (!user.isActivated()) {
+            throw NotFoundActiveUserException(user.email)
+        }
 
         return UserInfoDTO(
             id = user.id,

--- a/tomo/user/src/main/kotlin/place/tomo/user/infra/adapters/UserDomainAdapter.kt
+++ b/tomo/user/src/main/kotlin/place/tomo/user/infra/adapters/UserDomainAdapter.kt
@@ -5,18 +5,20 @@ import place.tomo.contract.dtos.UserInfoDTO
 import place.tomo.contract.ports.UserDomainPort
 import place.tomo.user.domain.services.UserDomainService
 import place.tomo.user.infra.repositories.UserRepository
+import java.util.UUID
 
 @Component
 class UserDomainAdapter(
     private val userRepository: UserRepository,
     private val userDomainService: UserDomainService,
 ) : UserDomainPort {
-    override fun findActiveByEmail(email: String): UserInfoDTO? {
-        val user = userRepository.findByEmailAndDeletedAtIsNull(email) ?: return null
+    override fun findActiveByEntityId(entityId: String): UserInfoDTO? {
+        val user = userRepository.findByEntityIdAndDeletedAtIsNull(UUID.fromString(entityId)) ?: return null
         require(user.isActivated())
 
         return UserInfoDTO(
             id = user.id,
+            entityId = user.entityId,
             email = user.email,
             name = user.username,
         )
@@ -30,15 +32,17 @@ class UserDomainAdapter(
 
         return UserInfoDTO(
             id = user.id,
+            entityId = user.entityId,
             email = user.email,
             name = user.username,
         )
     }
 
-    override fun softDelete(userId: place.tomo.contract.vo.UserId) {
+    override fun softDelete(userId: Long) {
         // 통합 포트 요구 사항상 구현 필요. 별도 커맨드 어댑터에서 처리하던 softDelete를 간단 구현.
-        val user = userRepository.findById(userId.value).orElse(null) ?: return
-        user.status = place.tomo.user.domain.constant.UserStatus.DEACTIVATED
+        val user = userRepository.findById(userId).orElse(null) ?: return
+
+        user.deactivate()
         userRepository.save(user)
     }
 }

--- a/tomo/user/src/main/kotlin/place/tomo/user/infra/repositories/UserRepository.kt
+++ b/tomo/user/src/main/kotlin/place/tomo/user/infra/repositories/UserRepository.kt
@@ -2,11 +2,14 @@ package place.tomo.user.infra.repositories
 
 import org.springframework.data.jpa.repository.JpaRepository
 import place.tomo.user.domain.entities.UserEntity
+import java.util.UUID
 
 interface UserRepository : JpaRepository<UserEntity, Long> {
     fun findByEmailAndDeletedAtIsNull(email: String): UserEntity?
 
+    fun findByEntityIdAndDeletedAtIsNull(entityId: UUID): UserEntity?
+
     fun findByEmail(email: String): UserEntity?
 
-    fun existsByEmail(email: String): Boolean
+    fun existsByEntityIdAndDeletedAtIsNull(entityId: UUID): Boolean
 }

--- a/tomo/user/src/test/kotlin/place/tomo/user/infra/adapters/UserDomainAdapterTest.kt
+++ b/tomo/user/src/test/kotlin/place/tomo/user/infra/adapters/UserDomainAdapterTest.kt
@@ -43,7 +43,7 @@ class UserDomainAdapterTest {
             val entity = UserEntity(id = userId, email = userEmail, username = userName)
             every { userRepository.findByEmailAndDeletedAtIsNull(entity.email) } returns entity
 
-            val dto = adapter.findActiveByEmail(entity.email)
+            val dto = adapter.findActiveByEntityId(entity.email)
 
             assertThat(dto).isEqualTo(
                 UserInfoDTO(
@@ -60,7 +60,7 @@ class UserDomainAdapterTest {
             val nonExistentEmail = faker.internet().emailAddress()
             every { userRepository.findByEmailAndDeletedAtIsNull(nonExistentEmail) } returns null
 
-            val dto = adapter.findActiveByEmail(nonExistentEmail)
+            val dto = adapter.findActiveByEntityId(nonExistentEmail)
 
             assertThat(dto).isNull()
         }


### PR DESCRIPTION
## 개요
<!-- **이 PR의 목적과 배경**을 간단히 설명해주세요. -->
oauth2ResourceServer에서 별도 convert를 구현하지 않으면 decode된 JWT를 AuthenticationPrincipal로 사용.
요청자 객체로 변환해 AuthenticationPrincipal로 사용할 수 있도록 개선.

## 변경사항 및 영향 범위
<!-- **어떤 코드가 변경되었는지, 어떤 서비스/모듈에 영향을 미치는지** 설명해주세요. -->
- JWT에서 subject를 추출해 user를 조회. AuthorizedUserDTO로 변환하도록 수정
- subject에 대응하는 사용자가 없거나, 비활성화된 경우 오류 처리
- 보안 상의 이유로 User의 email이나 id를 jwt subject로 사용하지 않고, uuid를 사용하도록 수정.
  -  UserEntity 필드에 entity id (UUID) 추가
  -  JWT 발급 시, user의 entity id (UUID)로 발급

## 리뷰어 집중 확인 포인트
<!-- 설계 의도, 보안/성능 우려 등 구체적으로 설명해주세요. -->
보안 상의 문제는 없을 지.


## 추가 자료
<!-- 스크린샷, 로그 캡처, API 요청/응답 샘플, 디자인 링크, 성능 측정 결과, 관련 문서/티켓 링크 -->


## 체크리스트

### 필수 항목
- [ ] 코드 변경
  - [ ] 새로운 의존성(라이브러리) 추가/변경 시, 업데이트
  - [ ] 환경변수/시크릿 추가·변경 시 모든 환경에 반영
- [ ] 데이터베이스 마이그레이션
 - [ ] 테이블/컬럼 추가·삭제·변경 등의 스키마 변경 사항이 있는지 확인
 - [ ] 스키마 변경이 필요한 경우, 마이그레이션 파일 생성 여부 확인
 - [ ] 스키마 변경이 필요한 경우, 기존 데이터 호환성 검토 (예: NOT NULL 제약 조건 추가 시 기본값 설정)
 - [ ] 운영 환경에서 마이그레이션 대상 데이터의 규모 및 마이그레이션 전략 수립 (예: 배치 처리, 다운타임 최소화, 롤링 마이그레이션, 멱등성 보장 등)
 - [ ] 트랜잭션 범위 적절성 검토 (예: 대용량 데이터 처리 시 트랜잭션 분할)
 - [ ] 롤백 계획 및 테스트 완료
- [ ] 보안
  - [ ] XSS/SQL Injection 등 보안 위험성 점검
  - [ ] 로그/디버그 코드, 민감정보 노출 여부 확인
- [ ] 모니터링
  - [ ] 새로운 로그/메트릭/알람 추가 또는 업데이트
  - [ ] 운영 시 확인해야 할 항목 문서화
- [ ] 문서화
  - [ ] 관련 문서(`README`) 최신화
  - [ ] API 스펙(`OpenAPI/Swagger`) 업데이트


